### PR TITLE
8일차 문제풀이실패

### DIFF
--- a/Study01 - Implementation/Day08/ysm_correct.cpp
+++ b/Study01 - Implementation/Day08/ysm_correct.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+using namespace std;
+
+typedef long long ll;
+int main() {
+	ll w, h, f, c, x1, y1, x2, y2;
+	cin >> w >> h >> f >> c >> x1 >> y1 >> x2 >> y2;
+	ll area = (x2 - x1) * (y2 - y1) * (c+1);
+	if (f <= w / 2) { 
+		if (f <= x1) { 
+			cout << w*h - area;
+		}
+		else { 
+			cout << w * h - (area + (min(f, x2) - x1) * (y2 - y1) * (c+1));
+		}
+	} 
+	else { 
+		if (w <= x1 + f) { 
+			cout << w * h - area;
+		}
+		else { 
+			cout << w * h - (area + (min(w, f + x2) - (f + x1)) * (y2 - y1) * (c+1));
+		}
+	}
+}
+

--- a/Study01 - Implementation/README.md
+++ b/Study01 - Implementation/README.md
@@ -50,7 +50,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [색칠 1](https://www.acmicpc.net/problem/1117) | 진홍 수민 현수 |
+| [색칠 1](https://www.acmicpc.net/problem/1117) | 진홍 [수민](Day08/ysm.cpp) 현수 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직
* 알고리즘 구축 실패
1. 접힌곳과 겹칠 경우와 겹치지 않을 경우를 구별할 수 있는 기준을 못 찾음
2. 접힌곳과 겹쳤을 경우 기존의 색칠된 구간 이외에 추가로 색칠되는 구간이 가로*(y2-y1)*(c+1)로 생기는데 여기서
가로 부분을 구하지 못함. 
![image](https://user-images.githubusercontent.com/68679529/194870735-416b78a8-c602-47ec-a679-54a3ed6248e9.png)

* 찾은 알고리즘 로직
처음에 색치된 부분 : area -> (x2-x1)(y2-y1)(c+1)
1. 왼쪽이 오른쪽보다 클 경우, 
   접힌 곳과 겹쳤을때 색칠된 부분은 area와 왼쪽부분에 추가로 색칠된부분으로  (min(f, x2) - x1) * (y2 - y1) * (c+1)이 된다. 
   접힌 곳과 겹치지 않았을 경우 색칠된 부분은 area만 존재한다. 
2. 오른쪽이 왼쪽보다 클 경우도 1번과 같다. 다만 접힌 곳과 겹쳤을때 추가로 색칠된 부분이  (min(w, f + x2) - (f + x1)) * (y2 - y1) * (c+1)으로 가로가 다르다.  

## 복잡도

시간복잡도 O(1)
공간복잡도 O(1)

## 채점 결과
알고리즘을 구축하지 못하여 채점도 못함...ㅠㅠㅠㅠㅠㅠ
