### PR TITLE
김진홍 9일차 문제 풀이

### DIFF
--- a/Study01 - Implementation/Day09/kjh.kt
+++ b/Study01 - Implementation/Day09/kjh.kt
@@ -1,0 +1,17 @@
+class Solution {
+    fun solution(w: Int, h: Int): Long {
+        var n = Math.min(w, h)
+        var m = Math.max(w, h)
+        
+        val gcd = getGCD(n, m)
+        n /= gcd
+        m /= gcd
+        
+        val cutSquares = n*(m/n+1)+(m%n)-1
+        
+        val result: Long = w.toLong() * h - (gcd * cutSquares)
+        return result
+    }
+    
+    fun getGCD(a: Int, b: Int): Int = if(b != 0) getGCD(b, a % b) else a
+}

--- a/Study01 - Implementation/README.md
+++ b/Study01 - Implementation/README.md
@@ -56,7 +56,7 @@
 
 | 문제                                                                         | 답안                |
 |----------------------------------------------------------------------------| ------------------- |
-| [멀쩡한 삼각형](https://school.programmers.co.kr/learn/courses/30/lessons/62048) | 진홍 수민 현수 |
+| [멀쩡한 삼각형](https://school.programmers.co.kr/learn/courses/30/lessons/62048) | [진홍](Day09/kjh.kt) 수민 현수 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직

노가다를 통해 세 규칙을 찾아냈습니다
1. w와 h가 뒤바뀌어도 결과는 같다
2. w*h의 잘려서 제외되는 정사각형 개수가 o라면, kw\*kh의 제외되는 개수는 k\*o다
3. n<m이고 n과 m이 소수일 때 n\*m의 제외되는 개수는 n\*(m//n+1)+(m%n)-1다

이 규칙을 바탕으로 아래와 같은 로직을 만들었습니다
1. n=w,h중 작은 값 m=w,h중 큰 값
2. n와 m를 각각 최대공약수로 나눈다
3. n*(m//n+1)+(m%n)-1 공식으로 제외 개수를 구하고 최대공약수를 곱한 값을 w*h에서 빼면 답

## 복잡도

시간복잡도 O(1)
공간복잡도 O(1)

## 채점 결과

![SCR-20221011-ikb](https://user-images.githubusercontent.com/33937365/194996635-0e935ed6-54f5-4117-a2b8-fd855869d5ff.png)

