### PR TITLE
김진홍 23일차 문제 풀이

### DIFF
--- a/Study02 - Sort/Day23/kjh.kt
+++ b/Study02 - Sort/Day23/kjh.kt
@@ -1,0 +1,33 @@
+fun main() {
+    val N = readln().toInt()
+    val honors = ArrayList<Int>()
+    repeat(N) {
+        val honor = readln().toInt()
+        honors.add(honor)
+    }
+    
+    val sortedHonors = quickSort(honors)
+    var hackers = 0L
+    var oneToN = 1
+    
+    for (honor in sortedHonors) {
+        val hackerNeeded = honor - oneToN
+        if (hackerNeeded >= 0) {
+            oneToN++
+            hackers += hackerNeeded
+        }
+    }
+    print(hackers)
+}
+
+fun quickSort(items: List<Int>): List<Int> {
+    if (items.size < 2) {
+        return items
+    }
+
+    val pivot = items[items.size / 2]
+    val left = items.filter { it < pivot }
+    val right = items.filter { it > pivot }
+
+    return quickSort(left) + items.filter { it == pivot } + quickSort(right)
+}

--- a/Study02 - Sort/README.md
+++ b/Study02 - Sort/README.md
@@ -53,7 +53,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [모독](https://www.acmicpc.net/problem/16678) | 진홍 수민 현수 |
+| [모독](https://www.acmicpc.net/problem/16678) | [진홍](Day23/kjh.kt) 수민 현수 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직

1. 오름차순 퀵소트
2. 각 명예 점수를 순회하며 아래를 실행한다 (i=1 초기화)
    1. 명예점수에서 i를 뺀다
    2. 1의 결과가 0 또는 양수일 경우
        * 1의 결과를 필요한 해커 수로 카운팅하고
        * i를 1 증가시킨다
3. 필요한 해커 수를 출력한다

## 복잡도

시간복잡도 O(NlogN)
공간복잡도 O(N)

## 채점 결과
![image](https://user-images.githubusercontent.com/33937365/197666698-b956f3e1-5555-45dc-9bda-3767c287162c.png)

## 개인적으로 쓰는 오답노트
1. 반례 1 2 2 2 5 (내 오답: 0, 정답: 2)
2. 정답이 Int 범위를 벗어날 수 있음을 놓침

실천할 것: 정답의 범위가 자료형의 범위를 넘지는 않나 고려해보자