### PR TITLE
한현수 34일차 문제 풀이 완료

### DIFF
--- a/Study03 - Stack, Queue, Deque/Day34/hhs.java
+++ b/Study03 - Stack, Queue, Deque/Day34/hhs.java
@@ -1,0 +1,56 @@
+package pro_118667;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+
+        long sumQueue1 = 0;
+        long sumQueue2 = 0;
+        int max = 0;
+        int answer = 0;
+
+        Deque<Integer> deque1 = new ArrayDeque<>();
+        Deque<Integer> deque2 = new ArrayDeque<>();
+
+        for (int i = 0; i < queue1.length; i++) {
+            deque1.add(queue1[i]);
+            deque2.add(queue2[i]);
+
+            sumQueue1 += queue1[i];
+            sumQueue2 += queue2[i];
+
+            max = Math.max(0, Math.max(queue1[i], queue2[i]));
+        }
+
+        long sumResult = (sumQueue1 + sumQueue2);
+        if (sumResult % 2 == 1 || sumResult / 2 < max) {
+            return -1;
+        }
+
+        while (true) {
+            if (sumQueue1 == sumQueue2) {
+                break;
+            } else if (sumQueue1 > sumQueue2) {
+                sumQueue2 += deque1.getFirst();
+                sumQueue1 -= deque1.getFirst();
+                deque2.addLast(deque1.removeFirst());
+            } else {
+                sumQueue1 += deque2.getFirst();
+                sumQueue2 -= deque2.getFirst();
+                deque1.addLast(deque2.removeFirst());
+            }
+            answer++;
+
+            if (answer == 300000) return -1;
+        }
+
+        return answer;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(new Solution().solution(new int[]{3, 2, 7, 2}, new int[]{4, 6, 5, 1}));
+    }
+
+}

--- a/Study03 - Stack, Queue, Deque/README.md
+++ b/Study03 - Stack, Queue, Deque/README.md
@@ -36,7 +36,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [두 큐 합 같게 만들기](https://school.programmers.co.kr/learn/courses/30/lessons/118667) | 진홍 수민 현수 희두 |
+| [두 큐 합 같게 만들기](https://school.programmers.co.kr/learn/courses/30/lessons/118667) | 진홍 수민 [현수](Day34/hhs.java) 희두 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직

1. 입력받은 값을 각각 두개의 큐에 넣고 각 큐의 합을 두개 구한다.
    1-1. 두 개 큐의 합을 둘다 더해서 홀수면 -1반환
    1-2. 큐의 값중 1-1에서 구한 합의 절반보다 초과면 -1반환
2. 투포인터를 이용한다 포인터의 위치는 각 포인터의 front(맨앞)
3. 각 큐(a, b라고하자)의 a의 합과 b의 합을 비교하면서 다음과 같은 분기가 나뉜다.
    3-1. a의 합이 b의 합보다 크면 b에서 poll한 값을 a에 offer
    3-2. b의 합이 a의 합보다 크면 a에서 poll한 값을 b에 offer
    3-3. a의 합과 b의 합이 같으면 반복 종료
    3-4. 300000만번 수행했으면 반복 종료
4. 3번 과정을 했으면 따로 answer 변수에 1을 더하고 다시 반복한다.
5. 출력 

## 복잡도

시간복잡도 O(N)
공간복잡도 O(N)

## 채점 결과

<img width="188" alt="스크린샷 2022-11-15 오후 10 53 55" src="https://user-images.githubusercontent.com/37373826/201936730-d2564b82-2714-4f3e-8902-dc966403416d.png">

카카오 문제는 예외를 어떻게 처리할지가 관건인거같네요.
