### PR TITLE
유수민 34일차 문제풀이 실패

### DIFF
--- a/Study03 - Stack, Queue, Deque/Day34/ysm.cpp
+++ b/Study03 - Stack, Queue, Deque/Day34/ysm.cpp
@@ -1,0 +1,72 @@
+#include <string>
+#include <vector>
+#include <iostream>
+ 
+using namespace std;
+ 
+int solution(vector<int> queue1, vector<int> queue2) {
+ 
+    //선언
+    int answer;                         //-> 정답
+    vector<int>::iterator ptr1, ptr2;   //-> 큐 포인터
+    long long sum_all, sum1, sum2;      //-> 큐1+큐2합, 큐1합, 큐2합
+ 
+    //초기화
+    answer = 0;
+    ptr1 = queue1.begin(), ptr2 = queue2.begin();
+    sum_all = 0, sum1 = 0, sum2 = 0;
+ 
+    /* 해법 */
+    //1. 큐1, 큐2, 큐1+큐2 원소 합 구하기
+    for (int i = 0; i < queue1.size(); i++) {
+        sum1 += queue1[i];
+        sum2 += queue2[i];
+    }
+    sum_all = sum1 + sum2;
+ 
+    //2. 큐1+큐2 원소 합이 홀수일 경우 -> 불가능
+    if (sum_all % 2 != 0) {
+        answer = -1;
+    }
+    else {
+        //3. 큐1, 큐2에 있는 두 개의 포인터를 조종하며 원소 합 구하기
+        while (true) {
+ 
+            //종료조건1 -> 두 큐의 합이 같을 경우
+            if (sum1 == sum2) {
+                break;
+            }
+ 
+            //종료조건2 -> 포인터1이 큐2 끝까지 갔을 경우 or 포인터2가 큐1 끝까지 갔을 경우(탐색완료)
+            if (ptr1 == queue2.end() || ptr1 == queue1.end()) {
+                answer = -1;
+                break;
+            }
+ 
+            //큐의 포인터 옮기기
+            if (sum1 > sum2) {
+                sum1 -= *ptr1;
+                sum2 += *ptr1;
+                
+                ptr1++;
+                if (ptr1 == queue1.end()) {
+                    ptr1 = queue2.begin();
+                }
+            }
+            else {
+                sum2 -= *ptr2;
+                sum1 += *ptr2;
+                
+                ptr2++;
+                if (ptr2 == queue2.end()) {
+                    ptr2 = queue1.begin();
+                }
+            }
+ 
+            answer++;
+        }
+    }
+ 
+    //반환
+    return answer;
+}

--- a/Study03 - Stack, Queue, Deque/Day34/ysm.cpp
+++ b/Study03 - Stack, Queue, Deque/Day34/ysm.cpp
@@ -1,72 +1,58 @@
 #include <string>
 #include <vector>
-#include <iostream>
- 
+#include <queue>
 using namespace std;
- 
+
 int solution(vector<int> queue1, vector<int> queue2) {
- 
-    //선언
-    int answer;                         //-> 정답
-    vector<int>::iterator ptr1, ptr2;   //-> 큐 포인터
-    long long sum_all, sum1, sum2;      //-> 큐1+큐2합, 큐1합, 큐2합
- 
-    //초기화
-    answer = 0;
-    ptr1 = queue1.begin(), ptr2 = queue2.begin();
-    sum_all = 0, sum1 = 0, sum2 = 0;
- 
-    /* 해법 */
-    //1. 큐1, 큐2, 큐1+큐2 원소 합 구하기
-    for (int i = 0; i < queue1.size(); i++) {
-        sum1 += queue1[i];
-        sum2 += queue2[i];
+    long long sum = 0, sum2 = 0;
+    queue<int> q, q2;
+
+    for (int num : queue1) {
+        sum += num;
+
+        q.push(num);
     }
-    sum_all = sum1 + sum2;
- 
-    //2. 큐1+큐2 원소 합이 홀수일 경우 -> 불가능
-    if (sum_all % 2 != 0) {
-        answer = -1;
+
+    for (int num : queue2) {
+        sum2 += num;
+
+        q2.push(num);
     }
-    else {
-        //3. 큐1, 큐2에 있는 두 개의 포인터를 조종하며 원소 합 구하기
-        while (true) {
- 
-            //종료조건1 -> 두 큐의 합이 같을 경우
-            if (sum1 == sum2) {
-                break;
-            }
- 
-            //종료조건2 -> 포인터1이 큐2 끝까지 갔을 경우 or 포인터2가 큐1 끝까지 갔을 경우(탐색완료)
-            if (ptr1 == queue2.end() || ptr1 == queue1.end()) {
-                answer = -1;
-                break;
-            }
- 
-            //큐의 포인터 옮기기
-            if (sum1 > sum2) {
-                sum1 -= *ptr1;
-                sum2 += *ptr1;
-                
-                ptr1++;
-                if (ptr1 == queue1.end()) {
-                    ptr1 = queue2.begin();
-                }
-            }
-            else {
-                sum2 -= *ptr2;
-                sum1 += *ptr2;
-                
-                ptr2++;
-                if (ptr2 == queue2.end()) {
-                    ptr2 = queue1.begin();
-                }
-            }
- 
-            answer++;
+
+    int idx = 0, idx2 = 0;
+    int maxIdx = queue1.size() + queue2.size();
+    int answer = 0;
+
+    while (idx < maxIdx && idx2 < maxIdx)
+    {
+        if (sum == sum2)
+        {
+            return answer;
+        }
+
+        answer++;
+
+        if (sum < sum2)
+        {
+            int cur = q2.front();
+            q2.pop();
+
+            q.push(cur);
+            sum += cur;
+            sum2 -= cur;
+            idx2++;
+        }
+        else
+        {
+            int cur = q.front();
+            q.pop();
+
+            q2.push(cur);
+            sum2 += cur;
+            sum -= cur;
+            idx++;
         }
     }
- 
-    //반환
-    return answer;
+
+    return -1;
 }

--- a/Study03 - Stack, Queue, Deque/Day34/ysmUsingTwoPointer.cpp
+++ b/Study03 - Stack, Queue, Deque/Day34/ysmUsingTwoPointer.cpp
@@ -1,0 +1,72 @@
+#include <string>
+#include <vector>
+#include <iostream>
+ 
+using namespace std;
+ 
+int solution(vector<int> queue1, vector<int> queue2) {
+ 
+    //선언
+    int answer;                         //-> 정답
+    vector<int>::iterator ptr1, ptr2;   //-> 큐 포인터
+    long long sum_all, sum1, sum2;      //-> 큐1+큐2합, 큐1합, 큐2합
+ 
+    //초기화
+    answer = 0;
+    ptr1 = queue1.begin(), ptr2 = queue2.begin();
+    sum_all = 0, sum1 = 0, sum2 = 0;
+ 
+    /* 해법 */
+    //1. 큐1, 큐2, 큐1+큐2 원소 합 구하기
+    for (int i = 0; i < queue1.size(); i++) {
+        sum1 += queue1[i];
+        sum2 += queue2[i];
+    }
+    sum_all = sum1 + sum2;
+ 
+    //2. 큐1+큐2 원소 합이 홀수일 경우 -> 불가능
+    if (sum_all % 2 != 0) {
+        answer = -1;
+    }
+    else {
+        //3. 큐1, 큐2에 있는 두 개의 포인터를 조종하며 원소 합 구하기
+        while (true) {
+ 
+            //종료조건1 -> 두 큐의 합이 같을 경우
+            if (sum1 == sum2) {
+                break;
+            }
+ 
+            //종료조건2 -> 포인터1이 큐2 끝까지 갔을 경우 or 포인터2가 큐1 끝까지 갔을 경우(탐색완료)
+            if (ptr1 == queue2.end() || ptr1 == queue1.end()) {
+                answer = -1;
+                break;
+            }
+ 
+            //큐의 포인터 옮기기
+            if (sum1 > sum2) {
+                sum1 -= *ptr1;
+                sum2 += *ptr1;
+                
+                ptr1++;
+                if (ptr1 == queue1.end()) {
+                    ptr1 = queue2.begin();
+                }
+            }
+            else {
+                sum2 -= *ptr2;
+                sum1 += *ptr2;
+                
+                ptr2++;
+                if (ptr2 == queue2.end()) {
+                    ptr2 = queue1.begin();
+                }
+            }
+ 
+            answer++;
+        }
+    }
+ 
+    //반환
+    return answer;
+}

--- a/Study03 - Stack, Queue, Deque/README.md
+++ b/Study03 - Stack, Queue, Deque/README.md
@@ -36,7 +36,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [두 큐 합 같게 만들기](https://school.programmers.co.kr/learn/courses/30/lessons/118667) | 진홍 수민 현수 희두 |
+| [두 큐 합 같게 만들기](https://school.programmers.co.kr/learn/courses/30/lessons/118667) | 진홍 [수민](Day34/ysm.cpp) 현수 희두 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직
 원소 이동을 최소로 하는 방법은 원소의 합이 큰 큐에서 원소를 빼서 작은 쪽으로 넣는 방법이다. 
원소이동 방법은 포인터를 이용한다. 
1. 두개의 큐를 입력받고 각 큐의 총합을 구한다.
2. 각 큐의 위치 탐색 인덱스가 끝까지 갔을 경우까지 아래 경우를 반복한다. 
3. 두 큐의 합 중 더 합이 큰 큐를 확인하여  큰 큐에서는 원소를 빼고 합이 더 작은 큐에서는 원소를 더해줘서 계속 비교한다. 
4. 큐에서 원소가 빠져나갔을 경우, 큐의 첫번째 원소의 인덱스가 원래 첫번째 원소 인덱스보다 +1이 되었으니 반영한다. 

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도와 공간복잡도 작성 -->
N: 큐의 크기
시간복잡도 O(N)
공간복잡도 O(N)

* 위의 코드와 달리 많은 사람들이 투 포인터 방법을 사용하였다. 내가 올린 코드가 난 더 이해가 잘 되어서 이 코드로 올린다. 투 포인터 방법,,,어렵다.
