### PR TITLE
정희두 34일차 문제풀이 실패

### DIFF
--- a/Study03 - Stack, Queue, Deque/Day34/jhd.cpp
+++ b/Study03 - Stack, Queue, Deque/Day34/jhd.cpp
@@ -1,0 +1,62 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+// 오답풀이
+int solution(vector<int> queue1, vector<int> queue2) {
+    // 문제에서 친철하게 오버플로우 발생 가능성을 말해줬으므로 크기가 큰 long 타입으로 지정하였습니다.
+
+    long long sum = 0, sum2 = 0;
+    queue<int> q, q2;
+
+    for (int num : queue1) {
+        sum += num;
+
+        q.push(num);
+    }
+
+    for (int num : queue2) {
+        sum2 += num;
+
+        q2.push(num);
+    }
+
+    int size = queue1.size() ;
+    int answer = 0;
+    // 두 배열의 길이가 같습니다. 두 배열의 길이의 합만큼 변경이 발생하면 배열의 위치가 변경됩니다.(size() * 2)
+    // 다시 원상태로 돌아오려면 위 작업을 한번 더 하면 됩니다. 원 위치가 되면 한바퀴 돌았기 때문에
+    // 다시 원상태가 되기 전까지만 확인하면 됩니다.
+    for(int i = 0; i < size * 4; i++ )
+    {   
+        // 반복중에 두개의 합이 같아지게 되면 지금 까지 카운트한 횟수를 반환합니다.
+        if (sum == sum2)
+        {
+            return answer;
+        }
+
+        // 같지 않다면 둘의 크기가 어떻든 작업은 무조건 이루어집니다.
+        answer++;   
+
+        // 두 배열 중에 큰 배열에서 작은 배열로 한개씩 옮겨야하기 때문에 조건에 따라 작업이 달라집니다.
+        if (sum < sum2)
+        {
+            int qfront = q2.front();
+            q2.pop();
+
+            q.push(qfront);
+            sum += qfront;
+            sum2 -= qfront;
+            
+        }
+        else
+        {
+            int qfront = q.front();
+            q.pop();
+
+            q2.push(qfront);
+            sum2 += qfront;
+            sum -= qfront;
+        }
+    }
+
+    return -1;
+}

--- a/Study03 - Stack, Queue, Deque/README.md
+++ b/Study03 - Stack, Queue, Deque/README.md
@@ -30,13 +30,13 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [회전하는 큐](https://www.acmicpc.net/problem/1021) | [진홍](Day33/kjh.kt) 수민 현수 희두 |
+| [회전하는 큐](https://www.acmicpc.net/problem/1021) | [진홍](Day33/kjh.kt) 수민 현수 [희두](Day33/jhd.cpp) |
 
 ## [34일차](Day34)
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [두 큐 합 같게 만들기](https://school.programmers.co.kr/learn/courses/30/lessons/118667) | 진홍 수민 현수 희두 |
+| [두 큐 합 같게 만들기](https://school.programmers.co.kr/learn/courses/30/lessons/118667) | 진홍 수민 현수 [희두](Day34/jhd.cpp) |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직

문제에서 친절하게 오버플로우를 말해줬습니다. 따라서 합의 타입은 long long으로 Int보다 크게 둡니다.
예외 : 두 배열의 합이 홀수일 경우 각 배열의 합은 같을 수 없습니다. -1 을 반환합니다.

1. 각 배열의 합을 구합니다.
2. 각 배열의 합을 비교합니다. 
  2-1. 배열의 합이 같으면 cnt를 반환합니다.  
3. cnt를 1 올립니다.
4. 합이 큰 배열에서 뽑아서 작은 배열로 하나씩 이동 시킵니다.(2개의 배열이 있으니 로직도 2개가 됩니다.)
5. 이동 시킨 원소를 합에도 추가 시킵니다.( 이렇게 되면 배열의 합의 대소가 변경되는 시점이 옵니다. 그렇게 계속 맞춰갑니다.)
6. 그러다 같은 시점이 안나오면 -1을 반환합니다. 


## 복잡도
시간복잡도 O(4N)
한번 끝까지 돌게 될 경우 주어진 두 배열이 두바퀴씩 돌아야하기 때문에 4N으로 했습니다.

공간복잡도 O(N)
같은 공간에 넣었다 뺐다하기 때문에 공간 복잡도는 이상 없습니다. 

## 채점 결과

실패
